### PR TITLE
fix(diagnostics): honor skills_toggle and plugins_api from /v1/capabilities

### DIFF
--- a/lib/core/services/connection_diagnostics.dart
+++ b/lib/core/services/connection_diagnostics.dart
@@ -437,19 +437,9 @@ class ConnectionDiagnostics {
       ),
     );
 
-    // 5b. skills toggle + plugins — confirm routes without mutating state.
-    //     Empty PUT body → 400/422 means the write path exists (same pattern
-    //     as the chat probe below). GET /v1/plugins lists installed plugins.
-    results.add(
-      await _probe(
-        'skills_toggle',
-        'PUT',
-        Uri.parse('$base/v1/skills/toggle'),
-        headers: auth,
-        body: <String, Object?>{},
-        okCodes: const {400, 422},
-      ),
-    );
+    // 5b. Plugins are safe to probe with GET. Skills toggle is intentionally
+    //     not probed: authenticated /v1/capabilities is authoritative and a
+    //     diagnostic flow must not issue a speculative mutating request.
     results.add(
       await _probe(
         'plugins',

--- a/lib/core/services/connection_diagnostics.dart
+++ b/lib/core/services/connection_diagnostics.dart
@@ -437,6 +437,28 @@ class ConnectionDiagnostics {
       ),
     );
 
+    // 5b. skills toggle + plugins — confirm routes without mutating state.
+    //     Empty PUT body → 400/422 means the write path exists (same pattern
+    //     as the chat probe below). GET /v1/plugins lists installed plugins.
+    results.add(
+      await _probe(
+        'skills_toggle',
+        'PUT',
+        Uri.parse('$base/v1/skills/toggle'),
+        headers: auth,
+        body: <String, Object?>{},
+        okCodes: const {400, 422},
+      ),
+    );
+    results.add(
+      await _probe(
+        'plugins',
+        'GET',
+        Uri.parse('$base/v1/plugins'),
+        headers: auth,
+      ),
+    );
+
     // 6. /v1/chat/completions con body inválido a propósito (messages vacío):
     //    confirma que la ruta existe sin ejecutar el agente. 400 = existe.
     results.add(
@@ -647,10 +669,9 @@ class ConnectionDiagnostics {
         ? CapState.unknown
         : (dashAuth.status == ProbeStatus.ok ? CapState.yes : CapState.no);
 
-    // Escrituras documentadas en API_AUDIT.md para hermes-agent 0.16.x:
-    // sesiones (POST/DELETE individual), cron completo y model/set existen
-    // cuando la lectura correspondiente funciona; memoria/config/skills son
-    // GET-only (Allow: GET verificado) y SOUL/plugins no tienen endpoint.
+    // Base 0.16.x notes kept for sessions/cron inference. hermes-agent ≥0.20
+    // declares skills_toggle + plugins_api (and matching endpoints) via
+    // /v1/capabilities — those must override the old GET-only assumption.
     final sessionsRead = fromProbe(gwSessions);
     final cronRead = fromProbe(find(dash, 'cron'));
     final modelsReadDash = fromProbe(find(dash, 'models/providers'));
@@ -721,8 +742,14 @@ class ConnectionDiagnostics {
         ]),
         serverCaps?.feature('skills_api'),
       ),
-      skillsToggle: CapState.no,
-      skillsInstall: CapState.no,
+      skillsToggle: srv(
+        'skillsToggle',
+        fromProbe(find(gw, 'skills_toggle')),
+        serverCaps?.feature('skills_toggle'),
+      ),
+      // Install still goes through Mobile Bridge scopes; gateway has no
+      // skills_install feature flag yet → leave probe-unknown (not hard NO).
+      skillsInstall: CapState.unknown,
       toolsetsRead: srvEndpoint(
         'toolsetsRead',
         fromProbe(find(gw, 'toolsets')),
@@ -745,7 +772,11 @@ class ConnectionDiagnostics {
         serverCaps?.feature('admin_config_rw'),
       ),
       logsRead: fromProbe(find(dash, 'logs')),
-      pluginsSupported: CapState.no,
+      pluginsSupported: srv(
+        'pluginsSupported',
+        fromProbe(find(gw, 'plugins')),
+        serverCaps?.feature('plugins_api'),
+      ),
       gatewayVersion: version,
       serverModel: serverCaps?.model,
       serverSourced: serverSourced,

--- a/test/connection_diagnostics_capabilities_test.dart
+++ b/test/connection_diagnostics_capabilities_test.dart
@@ -1,0 +1,160 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import 'package:hermes_android/core/services/connection_diagnostics.dart';
+import 'package:hermes_android/core/services/connection_manager.dart';
+
+SavedConnection _connection() => SavedConnection(
+  id: 'diagnostics-test',
+  label: 'Diagnostics test',
+  host: '127.0.0.1',
+  port: 8642,
+  apiKey: 'test-key',
+  onDeviceLoopback: true,
+);
+
+String _capabilities({
+  bool? skillsToggle,
+  bool? pluginsApi,
+  String skillsTogglePath = '/v1/skills/toggle',
+}) {
+  final features = <String, Object?>{
+    'skills_api': true,
+    'chat_completions': true,
+    if (skillsToggle != null) 'skills_toggle': skillsToggle,
+    if (pluginsApi != null) 'plugins_api': pluginsApi,
+  };
+  final endpoints = <String, Object?>{
+    if (skillsToggle != null)
+      'skills_toggle': {'method': 'PUT', 'path': skillsTogglePath},
+    if (pluginsApi != null)
+      'plugins': {'method': 'GET', 'path': '/v1/plugins'},
+  };
+  return jsonEncode({
+    'object': 'hermes.api_server.capabilities',
+    'features': features,
+    'endpoints': endpoints,
+  });
+}
+
+Future<({CapabilityMatrix matrix, List<http.Request> requests})> _run(
+  String capabilities, {
+  int pluginsStatus = 200,
+}) async {
+  final requests = <http.Request>[];
+  final diagnostics = ConnectionDiagnostics(
+    httpClient: MockClient((request) async {
+      requests.add(request);
+      switch (request.url.path) {
+        case '/health':
+          return http.Response(jsonEncode({'version': '0.20.4'}), 200);
+        case '/api/sessions':
+        case '/v1/models':
+        case '/v1/skills':
+        case '/v1/toolsets':
+          return http.Response('{}', 200);
+        case '/v1/capabilities':
+          return http.Response(capabilities, 200);
+        case '/v1/plugins':
+          return http.Response('{}', pluginsStatus);
+        case '/v1/skills/toggle':
+          return http.Response('{}', 422);
+        case '/v1/chat/completions':
+          return http.Response('{}', 400);
+        default:
+          return http.Response('{}', 404);
+      }
+    }),
+  );
+
+  try {
+    final (gateway, version, serverCaps) = await diagnostics.probeGateway(
+      _connection(),
+    );
+    return (
+      matrix: diagnostics.buildMatrix(
+        gateway,
+        const [],
+        version,
+        serverCaps: serverCaps,
+      ),
+      requests: requests,
+    );
+  } finally {
+    diagnostics.close();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'diagnostics does not probe a hard-coded skills toggle write endpoint',
+    () async {
+      final result = await _run(
+        _capabilities(
+          skillsToggle: true,
+          pluginsApi: true,
+          skillsTogglePath: '/v9/server-declared/skills/toggle',
+        ),
+      );
+
+      expect(
+        result.requests.where((request) => request.method == 'PUT'),
+        isEmpty,
+      );
+      expect(
+        result.requests.where(
+          (request) => request.url.path == '/v1/skills/toggle',
+        ),
+        isEmpty,
+      );
+      expect(
+        result.requests.where(
+          (request) =>
+              request.url.path == '/v9/server-declared/skills/toggle',
+        ),
+        isEmpty,
+      );
+      expect(result.matrix.skillsToggle, CapState.yes);
+      expect(result.matrix.isServerSourced('skillsToggle'), isTrue);
+    },
+  );
+
+  test('declared true capabilities are authoritative', () async {
+    final result = await _run(
+      _capabilities(skillsToggle: true, pluginsApi: true),
+    );
+
+    expect(result.matrix.skillsToggle, CapState.yes);
+    expect(result.matrix.pluginsSupported, CapState.yes);
+    expect(result.matrix.isServerSourced('skillsToggle'), isTrue);
+    expect(result.matrix.isServerSourced('pluginsSupported'), isTrue);
+  });
+
+  test('declared false capabilities are authoritative', () async {
+    final result = await _run(
+      _capabilities(skillsToggle: false, pluginsApi: false),
+    );
+
+    expect(result.matrix.skillsToggle, CapState.no);
+    expect(result.matrix.pluginsSupported, CapState.no);
+    expect(result.matrix.isServerSourced('skillsToggle'), isTrue);
+    expect(result.matrix.isServerSourced('pluginsSupported'), isTrue);
+  });
+
+  test('legacy server without toggle feature does not become a false YES', () async {
+    final result = await _run(
+      _capabilities(),
+      pluginsStatus: 404,
+    );
+
+    expect(result.matrix.skillsToggle, CapState.unknown);
+    expect(result.matrix.isServerSourced('skillsToggle'), isFalse);
+    expect(result.matrix.pluginsSupported, CapState.no);
+    expect(result.matrix.skillsInstall, CapState.unknown);
+  });
+}

--- a/test/turn_idempotency_contract_test.dart
+++ b/test/turn_idempotency_contract_test.dart
@@ -304,6 +304,44 @@ void main() {
     },
   );
 
+  test(
+    'skills_toggle y plugins_api declarados dejan de hardcodearse a NO',
+    () {
+      final caps = ServerCapabilities.tryParse(
+        jsonEncode({
+          'object': 'hermes.api_server.capabilities',
+          'features': {
+            'skills_toggle': true,
+            'plugins_api': true,
+            'skills_api': true,
+          },
+          'endpoints': {
+            'skills_toggle': {'method': 'PUT', 'path': '/v1/skills/toggle'},
+            'plugins': {'method': 'GET', 'path': '/v1/plugins'},
+          },
+        }),
+      );
+      final diagnostics = ConnectionDiagnostics(
+        httpClient: MockClient((_) async => http.Response('unused', 500)),
+      );
+      addTearDown(diagnostics.close);
+
+      final matrix = diagnostics.buildMatrix(
+        const [],
+        const [],
+        null,
+        serverCaps: caps,
+      );
+
+      expect(matrix.skillsToggle, CapState.yes);
+      expect(matrix.pluginsSupported, CapState.yes);
+      expect(matrix.isServerSourced('skillsToggle'), isTrue);
+      expect(matrix.isServerSourced('pluginsSupported'), isTrue);
+      // Without a bridge probe, install stays unknown (not forced NO).
+      expect(matrix.skillsInstall, CapState.unknown);
+    },
+  );
+
   test('capability ausente o corrupta conserva contrato heredado', () async {
     SharedPreferences.setMockInitialValues({
       'capabilities_corrupt': '{no-json',


### PR DESCRIPTION
## Problem
On Hermes Agent ≥0.20, `GET /v1/capabilities` correctly declares:

- `features.skills_toggle: true` + endpoint `PUT /v1/skills/toggle`
- `features.plugins_api: true` + endpoint `GET/PUT /v1/plugins*`

Console diagnostics still showed **SKILLS (TOGGLE): NO** and **PLUGINS: NO** because `buildMatrix()` hard-coded:

```dart
skillsToggle: CapState.no,
skillsInstall: CapState.no,
pluginsSupported: CapState.no,
```

So the UI ignored the server declaration (`·SRV` never applied) even when routes worked.

## Fix
1. Map `skills_toggle` / `plugins_api` through the existing `srv()` helper (server declaration wins).
2. Add non-mutating gateway probes:
   - `PUT /v1/skills/toggle` empty body → accept 400/422 (route exists)
   - `GET /v1/plugins` → list
3. Stop forcing `skillsInstall` to NO without a bridge probe (leave `unknown`; install remains Bridge-scoped).

## Test plan
- [x] Unit test: declared features → matrix YES + serverSourced
- [ ] Manual: pair against hermes 0.20.4 with skills_toggle/plugins_api true → diagnostics chips YES ·SRV
- [ ] Regression: older agent without those features still shows NO/unknown, not false YES