### PR TITLE
fix(chat): handle active session ownership safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 All notable public changes are documented here. Internal QA/profile artifacts
 are not releases.
 
-## 1.2.9 (4963)
+## 1.2.9 (4964)
 
+- Replaced raw Desktop session-owner rejections with private, actionable UI,
+  preserved the server's structured rejection reason and made safe retries
+  replace the failed local turn instead of duplicating it.
 - Fixed chat history disappearing, reordering or losing visible content during
   overlapping refreshes, pagination, reconnection and Desktop snapshot
   recovery.

--- a/docs/RELEASE_1.2.9_NOTES.md
+++ b/docs/RELEASE_1.2.9_NOTES.md
@@ -4,6 +4,9 @@
 
 - Los chats conservan el historial visible durante refreshes solapados,
   reconexiones, paginación y recuperación desde Desktop.
+- Si una conversación ya está abierta en Desktop u otro dispositivo, Console
+  muestra una explicación privada y permite reintentar sin duplicar el turno ni
+  revelar identificadores internos del servidor.
 - Al volver a la app después de ejecutar herramientas como búsqueda web, el
   turno se reengancha y la respuesta final se recupera automáticamente.
 - `Parar` conserva de forma durable la cancelación sin resucitar respuestas

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -5808,6 +5808,9 @@ class _ChatScreenState extends State<ChatScreen>
           restoresComposer: usesComposerState,
         ) ??
         false;
+    final replacesProvenRejectedProjection =
+        sameRecoveredBatch &&
+        existing!.state == PreparedTurnState.failedBeforeAcceptance;
     final prepared = PreparedTurn(
       connectionId: widget.connection.id,
       sessionId: widget.session.id,
@@ -5850,6 +5853,10 @@ class _ChatScreenState extends State<ChatScreen>
       _observeAttachmentDelivery(null);
       _scheduleDraftSave();
       return false;
+    }
+
+    if (replacesProvenRejectedProjection) {
+      _removeLatestFailedPromptProjection(fullText);
     }
 
     // Historial conversacional para el run (formato OpenAI, orden cronológico).
@@ -6050,16 +6057,10 @@ class _ChatScreenState extends State<ChatScreen>
   /// Retry the last failed send.
   void _retryLastPrompt() {
     if (_lastPrompt.isEmpty) return;
-    // Remove the error entry
-    if (_messages.isNotEmpty && _messages[0]['role'] == 'assistant_error') {
-      _messages.removeAt(0);
-    }
-    // Remove the user message that preceded it
-    if (_messages.isNotEmpty &&
-        _messages[0]['role'] == 'user' &&
-        _messages[0]['content'] == _lastPrompt) {
-      _messages.removeAt(0);
-    }
+    _removeLatestFailedPromptProjection(
+      _lastPrompt,
+      allowLegacyContentPair: true,
+    );
     // En un fallo previo al ACK, el composer ya conserva el texto y todos los
     // adjuntos originales. Solo reconstruimos desde lastPrompt para sesiones
     // antiguas o fallos posteriores al ACK donde el composer sí estaba vacío.
@@ -6068,6 +6069,32 @@ class _ChatScreenState extends State<ChatScreen>
     }
     setState(() => _pipelineState = ChatPipelineState.idle);
     _sendMessage();
+  }
+
+  bool _removeLatestFailedPromptProjection(
+    String prompt, {
+    bool allowLegacyContentPair = false,
+  }) {
+    if (_messages.isEmpty) return false;
+    final error = _messages.first;
+    if (error['role'] != 'assistant_error' ||
+        (error['_prompt'] ?? '').toString() != prompt) {
+      return false;
+    }
+    final projectionId = error['_localTranscriptProjectionId'];
+    _messages.removeAt(0);
+    if (_messages.isEmpty || _messages.first['role'] != 'user') return true;
+    final user = _messages.first;
+    final paired =
+        projectionId is String &&
+        projectionId.isNotEmpty &&
+        user['_localTranscriptPairId'] == projectionId;
+    final legacyPair =
+        allowLegacyContentPair &&
+        projectionId == null &&
+        (user['content'] ?? '').toString() == prompt;
+    if (paired || legacyPair) _messages.removeAt(0);
+    return true;
   }
 
   int? _userOrdinalFor(Map<String, dynamic> target) {
@@ -11162,7 +11189,7 @@ class _ChatScreenState extends State<ChatScreen>
     if (role == 'assistant_error') {
       final prompt = (msg['_prompt'] as String?) ?? _lastPrompt;
       return _ErrorBubble(
-        error: content,
+        error: activeChatStoredErrorUiMessage(content),
         onRetry: () => _retryLastPrompt(),
         prompt: prompt,
         onRestartGateway: _restartGatewayFromChat,

--- a/lib/core/services/active_chat_service.dart
+++ b/lib/core/services/active_chat_service.dart
@@ -76,6 +76,47 @@ String activeChatDesktopRecoveryDiagnostic(Object error) {
       '(${error.runtimeType}$code)';
 }
 
+const _sessionNotOwnedReason = 'SESSION_NOT_OWNED';
+const _maxConcurrentSessionsReason = 'MAX_CONCURRENT_SESSIONS';
+const _sessionCoordinationUnavailableReason =
+    'SESSION_COORDINATION_UNAVAILABLE';
+
+@visibleForTesting
+bool activeChatPromptWasRejectedBeforeAcceptance(Object error) =>
+    error is TuiGatewayRpcError &&
+    error.method == 'prompt.submit' &&
+    error.code == 4090;
+
+@visibleForTesting
+String activeChatPromptFailureUiMessage(Object error) {
+  if (error is TuiGatewayRpcError && error.method == 'prompt.submit') {
+    return switch (error.reason) {
+      _sessionNotOwnedReason =>
+        'Esta conversación está abierta en otra ventana o dispositivo. '
+            'Ciérrala allí y vuelve a intentarlo.',
+      _maxConcurrentSessionsReason =>
+        'Hermes tiene el máximo de sesiones activas. '
+            'Cierra otra sesión y vuelve a intentarlo.',
+      _sessionCoordinationUnavailableReason =>
+        'Hermes no pudo reservar esta conversación con seguridad. '
+            'Revisa el servidor y vuelve a intentarlo.',
+      _ => 'No se pudo enviar el mensaje. Inténtalo de nuevo.',
+    };
+  }
+  return 'No se pudo enviar el mensaje. Inténtalo de nuevo.';
+}
+
+/// Redacta únicamente el formato técnico que builds antiguas pudieron guardar
+/// en el transcript local. No se usa para decidir entrega ni reintentos: esas
+/// decisiones dependen del código y `error.data.reason` estructurados.
+String activeChatStoredErrorUiMessage(String error) {
+  if (error.trimLeft().startsWith('TuiGatewayRpcError(prompt.submit, 4090):')) {
+    return 'Hermes no pudo reservar esta conversación. '
+        'Revisa otras sesiones activas y vuelve a intentarlo.';
+  }
+  return error;
+}
+
 List<Map<String, dynamic>> _sanitizeDesktopFailureProjection(
   Iterable<Map<String, dynamic>> projected,
 ) => projected
@@ -1691,9 +1732,29 @@ class ActiveTurnDelivery {
     if (_acknowledged) return;
     final next = _current.copyWith(
       updatedAtMs: _nowMs(),
-      state: _transportStarted
+      state: _current.state == PreparedTurnState.failedBeforeAcceptance
+          ? PreparedTurnState.failedBeforeAcceptance
+          : _transportStarted
           ? PreparedTurnState.ambiguous
           : PreparedTurnState.failedBeforeAcceptance,
+    );
+    _current = next;
+    try {
+      await _store.save(next);
+    } catch (_) {
+      _persistenceFailed = true;
+    }
+  });
+
+  /// El servidor respondió con un rechazo que garantiza que no persistió ni
+  /// inició el turno. Aunque el request cruzó el transporte, conservarlo como
+  /// `ambiguous` sería falso y obligaría a tratar un retry seguro como posible
+  /// duplicado.
+  Future<void> markRejectedBeforeAcceptance() => _serializeMutation(() async {
+    if (_acknowledged) return;
+    final next = _current.copyWith(
+      updatedAtMs: _nowMs(),
+      state: PreparedTurnState.failedBeforeAcceptance,
     );
     _current = next;
     try {
@@ -7553,11 +7614,16 @@ class ActiveChat {
       } else {
         debugPrint('[active-chat] Desktop turn failed (${error.runtimeType})');
       }
-      if (idempotentSubmission) {
+      final rejectedBeforeAcceptance =
+          activeChatPromptWasRejectedBeforeAcceptance(error);
+      if (idempotentSubmission && !rejectedBeforeAcceptance) {
         // Anunciada pero incompatible (method-not-found, eco/payload inválido o
         // timeout): se invalida durante esta generación. No hay fallback porque
         // el servidor pudo haber aceptado el turno.
         _turnIdempotencyInvalid = true;
+      }
+      if (rejectedBeforeAcceptance) {
+        await _activeTurnDelivery?.markRejectedBeforeAcceptance();
       }
       _firstTokenTimer?.cancel();
       _firstTokenTimer = null;
@@ -7569,7 +7635,7 @@ class ActiveChat {
       if (!submissionAttempted && sessionConfig.allowTransportFallback) {
         return fallback();
       } else {
-        _failRun(error.toString());
+        _failRun(activeChatPromptFailureUiMessage(error));
         return false;
       }
     }

--- a/lib/core/services/tui_gateway_client.dart
+++ b/lib/core/services/tui_gateway_client.dart
@@ -36,8 +36,21 @@ class TuiGatewayRpcError implements Exception {
   final String method;
   final int? code;
   final String message;
+  final Map<String, dynamic> data;
 
-  const TuiGatewayRpcError(this.method, this.message, {this.code});
+  const TuiGatewayRpcError(
+    this.method,
+    this.message, {
+    this.code,
+    this.data = const <String, dynamic>{},
+  });
+
+  String? get reason {
+    final value = data['reason'];
+    if (value is! String) return null;
+    final normalized = value.trim();
+    return normalized.isEmpty ? null : normalized;
+  }
 
   @override
   String toString() => 'TuiGatewayRpcError($method, $code): $message';
@@ -926,6 +939,11 @@ class TuiGatewayClient
                   ? 'Hermes rejected the sensitive response'
                   : (map['message'] ?? 'Unknown JSON-RPC error').toString(),
               code: (map['code'] as num?)?.toInt(),
+              data: map['data'] is Map
+                  ? Map<String, dynamic>.unmodifiable(
+                      Map<String, dynamic>.from(map['data'] as Map),
+                    )
+                  : const <String, dynamic>{},
             ),
           );
         } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.2.9+4963
+version: 1.2.9+4964
 
 environment:
   sdk: ^3.12.0

--- a/sbom/fullRelease.cdx.json
+++ b/sbom/fullRelease.cdx.json
@@ -5680,7 +5680,7 @@
       "version": "2.2.0"
     },
     {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4963",
+      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -5701,9 +5701,9 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4963",
+      "purl": "pkg:pub/hermes_android@1.2.9+4964",
       "type": "application",
-      "version": "1.2.9+4963"
+      "version": "1.2.9+4964"
     },
     {
       "bom-ref": "pkg:pub/highlight@0.7.0",
@@ -9899,7 +9899,7 @@
         "pkg:pub/whisper_ggml_plus@1.5.2",
         "pkg:pub/xterm@4.0.0"
       ],
-      "ref": "pkg:pub/hermes_android@1.2.9+4963"
+      "ref": "pkg:pub/hermes_android@1.2.9+4964"
     },
     {
       "dependsOn": [
@@ -11010,7 +11010,7 @@
   ],
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4963",
+      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -11031,14 +11031,14 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4963",
+      "purl": "pkg:pub/hermes_android@1.2.9+4964",
       "type": "application",
-      "version": "1.2.9+4963"
+      "version": "1.2.9+4964"
     },
     "properties": [
       {
         "name": "hermes.input.sha256",
-        "value": "39b17014883ac4304f3ab4b61e2ab42ed051656736c68b2e2dd6da27581dd117"
+        "value": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
       },
       {
         "name": "hermes.android.variant",
@@ -11050,7 +11050,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:261cc943-aa17-4307-af95-6caace53b129",
+  "serialNumber": "urn:uuid:9393d78c-3bf5-492f-a774-0fad263ba0fe",
   "specVersion": "1.6",
   "version": 1
 }

--- a/sbom/fullRelease.license-review.json
+++ b/sbom/fullRelease.license-review.json
@@ -1,5 +1,5 @@
 {
-  "inputFingerprint": "39b17014883ac4304f3ab4b61e2ab42ed051656736c68b2e2dd6da27581dd117",
+  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077",
   "status": "COMPLETE",
   "unresolvedComponents": [],
   "unresolvedSourceAssets": [],

--- a/sbom/playRelease.cdx.json
+++ b/sbom/playRelease.cdx.json
@@ -5680,7 +5680,7 @@
       "version": "2.2.0"
     },
     {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4963",
+      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -5701,9 +5701,9 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4963",
+      "purl": "pkg:pub/hermes_android@1.2.9+4964",
       "type": "application",
-      "version": "1.2.9+4963"
+      "version": "1.2.9+4964"
     },
     {
       "bom-ref": "pkg:pub/highlight@0.7.0",
@@ -9899,7 +9899,7 @@
         "pkg:pub/whisper_ggml_plus@1.5.2",
         "pkg:pub/xterm@4.0.0"
       ],
-      "ref": "pkg:pub/hermes_android@1.2.9+4963"
+      "ref": "pkg:pub/hermes_android@1.2.9+4964"
     },
     {
       "dependsOn": [
@@ -11010,7 +11010,7 @@
   ],
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4963",
+      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -11031,14 +11031,14 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4963",
+      "purl": "pkg:pub/hermes_android@1.2.9+4964",
       "type": "application",
-      "version": "1.2.9+4963"
+      "version": "1.2.9+4964"
     },
     "properties": [
       {
         "name": "hermes.input.sha256",
-        "value": "39b17014883ac4304f3ab4b61e2ab42ed051656736c68b2e2dd6da27581dd117"
+        "value": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
       },
       {
         "name": "hermes.android.variant",
@@ -11050,7 +11050,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:bbbeb65f-f150-49c2-a993-2097c3eae224",
+  "serialNumber": "urn:uuid:eab09ab3-0587-4733-a907-fdb43306fca2",
   "specVersion": "1.6",
   "version": 1
 }

--- a/sbom/playRelease.license-review.json
+++ b/sbom/playRelease.license-review.json
@@ -1,5 +1,5 @@
 {
-  "inputFingerprint": "39b17014883ac4304f3ab4b61e2ab42ed051656736c68b2e2dd6da27581dd117",
+  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077",
   "status": "COMPLETE",
   "unresolvedComponents": [],
   "unresolvedSourceAssets": [],

--- a/sbom/source-assets.json
+++ b/sbom/source-assets.json
@@ -641,5 +641,5 @@
       "size": 127920
     }
   ],
-  "inputFingerprint": "39b17014883ac4304f3ab4b61e2ab42ed051656736c68b2e2dd6da27581dd117"
+  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
 }

--- a/test/active_chat_service_test.dart
+++ b/test/active_chat_service_test.dart
@@ -533,6 +533,63 @@ void main() {
     );
   });
 
+  test('prompt admission uses structured reasons without exposing detail', () {
+    const expected = <String, String>{
+      'SESSION_NOT_OWNED':
+          'Esta conversación está abierta en otra ventana o dispositivo. '
+          'Ciérrala allí y vuelve a intentarlo.',
+      'MAX_CONCURRENT_SESSIONS':
+          'Hermes tiene el máximo de sesiones activas. '
+          'Cierra otra sesión y vuelve a intentarlo.',
+      'SESSION_COORDINATION_UNAVAILABLE':
+          'Hermes no pudo reservar esta conversación con seguridad. '
+          'Revisa el servidor y vuelve a intentarlo.',
+    };
+
+    for (final entry in expected.entries) {
+      final error = TuiGatewayRpcError(
+        'prompt.submit',
+        'private session id and process detail',
+        code: 4090,
+        data: {'reason': entry.key},
+      );
+      expect(activeChatPromptWasRejectedBeforeAcceptance(error), isTrue);
+      expect(activeChatPromptFailureUiMessage(error), entry.value);
+      expect(
+        activeChatPromptFailureUiMessage(error),
+        isNot(contains('private')),
+      );
+    }
+
+    const unknown = TuiGatewayRpcError(
+      'prompt.submit',
+      'private provider detail',
+      code: 5001,
+    );
+    expect(activeChatPromptWasRejectedBeforeAcceptance(unknown), isFalse);
+    expect(
+      activeChatPromptFailureUiMessage(unknown),
+      'No se pudo enviar el mensaje. Inténtalo de nuevo.',
+    );
+  });
+
+  test('stored 4090 errors from older builds are redacted for display', () {
+    const legacy =
+        'TuiGatewayRpcError(prompt.submit, 4090): Session private-id '
+        'already has a live owner (desktop, pid 1234)';
+    const ordinary = 'No se pudo conectar con Hermes.';
+
+    final safe = activeChatStoredErrorUiMessage(legacy);
+    expect(
+      safe,
+      'Hermes no pudo reservar esta conversación. '
+      'Revisa otras sesiones activas y vuelve a intentarlo.',
+    );
+    expect(safe, isNot(contains('TuiGatewayRpcError')));
+    expect(safe, isNot(contains('private-id')));
+    expect(activeChatStoredErrorUiMessage(ordinary), ordinary);
+  });
+
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUp(() => SharedPreferences.setMockInitialValues({}));
@@ -546,6 +603,23 @@ void main() {
       sizeBytes: 3,
       localPath: '/private/informe.pdf',
     );
+
+    test('rechazo explícito nunca degrada después a entrega ambigua', () async {
+      final store = _AttachmentMemoryOutbox();
+      final delivery = ActiveTurnDelivery(
+        prepared: _attachmentTurn(pending),
+        store: store,
+      );
+
+      expect(
+        await delivery.beginTransport(PreparedTurnTransport.desktop),
+        isTrue,
+      );
+      await delivery.markRejectedBeforeAcceptance();
+      await delivery.markUnaccepted();
+
+      expect(delivery.current.state, PreparedTurnState.failedBeforeAcceptance);
+    });
 
     test(
       'attempt fence impide que un callback tardío reviva removed',

--- a/test/chat_screen_test.dart
+++ b/test/chat_screen_test.dart
@@ -745,6 +745,19 @@ class _SubmissionGateway
   }
 }
 
+class _ReasonedPromptRejection extends TuiGatewayRpcError {
+  const _ReasonedPromptRejection({required this.reason})
+    : super(
+        'prompt.submit',
+        'Session private-id already has a live owner '
+            '(desktop, pid 123456, running 33m)',
+        code: 4090,
+      );
+
+  @override
+  final String reason;
+}
+
 class _RecoverableSubmissionGateway extends _SubmissionGateway
     implements HermesDesktopIdempotentGateway {
   int statusCalls = 0;
@@ -4597,6 +4610,117 @@ void main() {
     expect(secureStore.containsKey('chat_turn_outbox_v1'), isFalse);
     expect(tester.takeException(), isNull);
   });
+
+  testWidgets(
+    'un error owner guardado por una build anterior nunca revela el RPC',
+    (tester) async {
+      const prompt = 'continúa esta conversación desde el móvil';
+      const raw =
+          'TuiGatewayRpcError(prompt.submit, 4090): Session private-id '
+          'already has a live owner (desktop, pid 1234)';
+
+      await pumpChat(
+        tester,
+        messages: const [
+          {'role': 'assistant_error', 'content': raw, '_prompt': prompt},
+          {'role': 'user', 'content': prompt},
+        ],
+      );
+
+      expect(
+        find.text(
+          'Hermes no pudo reservar esta conversación. '
+          'Revisa otras sesiones activas y vuelve a intentarlo.',
+        ),
+        findsOneWidget,
+      );
+      expect(find.textContaining('TuiGatewayRpcError'), findsNothing);
+      expect(find.textContaining('private-id'), findsNothing);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'rechazo por owner muestra copia segura y reintenta sin duplicar el turno',
+    (tester) async {
+      const prompt = 'continúa esta conversación desde el móvil';
+      const safeMessage =
+          'Esta conversación está abierta en otra ventana o dispositivo. '
+          'Ciérrala allí y vuelve a intentarlo.';
+      final connection = _remoteConn('conn-owned-elsewhere');
+      final gateway = _SubmissionGateway()
+        ..submitError = const _ReasonedPromptRejection(
+          reason: 'SESSION_NOT_OWNED',
+        );
+      final chat = await pumpChat(
+        tester,
+        connection: connection,
+        desktopGateway: gateway,
+      );
+
+      final field = find.byType(TextField).last;
+      await tester.enterText(field, prompt);
+      await tester.pump();
+      await tester.tap(find.byKey(const ValueKey('send')));
+      for (
+        var frame = 0;
+        frame < 40 && chat.state != ChatPipelineState.failed;
+        frame++
+      ) {
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+
+      expect(chat.state, ChatPipelineState.failed);
+      expect(find.text(safeMessage), findsOneWidget);
+      expect(find.textContaining('TuiGatewayRpcError'), findsNothing);
+      expect(find.textContaining('private-id'), findsNothing);
+      expect(
+        chat.messages.where((message) => message['role'] == 'user'),
+        hasLength(1),
+      );
+      var stored =
+          jsonDecode(secureStore['chat_turn_outbox_v1']!)
+              as Map<String, dynamic>;
+      expect(
+        (stored.values.single as Map<String, dynamic>)['state'],
+        PreparedTurnState.failedBeforeAcceptance.name,
+      );
+
+      // El rechazo conserva el lote en el composer. Pulsar la flecha verde es
+      // también un retry explícito y no debe apilar otra copia local del mismo
+      // user/error antes de volver a intentar el RPC.
+      expect(tester.widget<TextField>(field).controller?.text, prompt);
+      await tester.tap(find.byKey(const ValueKey('send')));
+      for (
+        var frame = 0;
+        frame < 40 && gateway.submissions.length < 2;
+        frame++
+      ) {
+        await tester.pump(const Duration(milliseconds: 20));
+      }
+      await tester.pump();
+
+      expect(gateway.submissions, [prompt, prompt]);
+      expect(
+        chat.messages.where((message) => message['role'] == 'user'),
+        hasLength(1),
+      );
+      expect(
+        chat.messages.where((message) => message['role'] == 'assistant_error'),
+        hasLength(1),
+      );
+      expect(find.text(safeMessage), findsOneWidget);
+      expect(find.textContaining('TuiGatewayRpcError'), findsNothing);
+      stored =
+          jsonDecode(secureStore['chat_turn_outbox_v1']!)
+              as Map<String, dynamic>;
+      expect(
+        (stored.values.single as Map<String, dynamic>)['state'],
+        PreparedTurnState.failedBeforeAcceptance.name,
+      );
+      expect(tester.takeException(), isNull);
+    },
+  );
 
   testWidgets(
     'submit vivo limpia el input y no permite doble envío o steering',

--- a/test/tui_gateway_client_test.dart
+++ b/test/tui_gateway_client_test.dart
@@ -258,6 +258,51 @@ void main() {
     },
   );
 
+  test('conserva el motivo estructurado de un rechazo JSON-RPC', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(server.close);
+    server.listen((request) async {
+      final socket = await WebSocketTransformer.upgrade(request);
+      await for (final raw in socket) {
+        final frame = jsonDecode(raw as String) as Map<String, dynamic>;
+        socket.add(
+          jsonEncode({
+            'jsonrpc': '2.0',
+            'id': frame['id'],
+            'error': {
+              'code': 4090,
+              'message': 'private remote ownership detail',
+              'data': {'reason': 'SESSION_NOT_OWNED'},
+            },
+          }),
+        );
+      }
+    });
+
+    final client = TuiGatewayClient(
+      SavedConnection(
+        id: 'conn-structured-error',
+        label: 'Structured error',
+        host: '127.0.0.1',
+        port: 8642,
+        apiKey: 'gateway-key',
+        dashboardUrl: 'http://127.0.0.1:${server.port}',
+      ),
+      dashboard: _TicketDashboardClient(),
+    );
+    addTearDown(client.close);
+
+    Object? captured;
+    try {
+      await client.submitPrompt('runtime-owned', 'continúa');
+    } catch (error) {
+      captured = error;
+    }
+
+    expect(captured, isA<TuiGatewayRpcError>());
+    expect((captured as dynamic).reason, 'SESSION_NOT_OWNED');
+  });
+
   test(
     'no ancla eventos legacy tras ligar dos runtimes en el mismo socket',
     () async {


### PR DESCRIPTION
## Resumen

- conserva el motivo estructurado de los rechazos de prompt del Gateway
- reemplaza el error técnico por mensajes privados y accionables
- conserva el estado failed-before-acceptance y evita duplicados al reintentar
- redacta errores 4090 guardados por builds anteriores
- publica Hermes Console 1.2.9 con versionCode 4964

## Validación local

- Flutter 3.44.1: analyze limpio
- Flutter 3.44.1: 4170 pruebas completas aprobadas, secuenciales
- 35 pruebas Python aprobadas
- REUSE 3.3 aprobado
- SBOM Play y Full completos, sin componentes ni assets sin resolver
- preflight Play: firma, fallo seguro, manifest y separación de permisos aprobados
- QA 1.2.9-qa build 4964 instalada in-place en Pixel físico