### PR TITLE
fix(ci): make release publishing repository-explicit

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -194,9 +194,13 @@ jobs:
           mapfile -d '' release_files < <(find release-artifacts/release-public \
             -maxdepth 1 -type f -print0 | sort -z)
           test "${#release_files[@]}" -gt 0
+          # This job intentionally has no checkout. Keep the repository
+          # explicit so gh never falls back to Git metadata discovery.
           gh release create "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             --title "Hermes Console $RELEASE_TAG" \
             --generate-notes \
             "${release_files[@]}" || \
           gh release upload "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
             "${release_files[@]}" --clobber

--- a/test/security_hardening_test.py
+++ b/test/security_hardening_test.py
@@ -174,6 +174,12 @@ class ReleaseWorkflowBoundaryTest(unittest.TestCase):
         self.assertIn("-printf '%f\\0'", self.workflow)
         self.assertIn("xargs -0 sha256sum > SHA256SUMS", self.workflow)
 
+    def test_release_commands_have_explicit_repository_context(self):
+        self.assertEqual(
+            self.workflow.count('--repo "$GITHUB_REPOSITORY"'),
+            2,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- pass `--repo "$GITHUB_REPOSITORY"` to both release create and upload commands
- document why repository discovery is unavailable in the checkout-free publish job
- add a regression test covering both commands

## Validation

- `python3 -m unittest discover -s test -p "*_test.py"` — 36 passed
- `uvx --from reuse==6.2.0 reuse lint` — 984/984 compliant
- workflow YAML parses successfully
- `gh release view --repo ...` succeeds outside a Git worktree

## Context

The v1.2.9 build, tests, signing, evidence generation, and artifact upload all succeeded. Only the final publish job failed because `gh` attempted Git metadata discovery in a job that intentionally has no checkout.