### PR TITLE
fix(bots): resume hidden Bot Chat without a Desktop ui_meta pin

### DIFF
--- a/lib/core/models/agent_profile.dart
+++ b/lib/core/models/agent_profile.dart
@@ -188,6 +188,30 @@ class AgentProfile {
           botModeUiMeta['chat'] != null &&
           botChatSessionId == null);
 
+  /// Desktop writes `chat: null` while recreating the forever-chat.
+  /// A missing `chat` key is not a reset: appearance-only `hermes-bots`
+  /// metadata is common on stock Agent installs.
+  bool get desktopClearedBotChatPin =>
+      botModeUiMeta.containsKey('chat') && botModeUiMeta['chat'] == null;
+
+  /// Gateway-native Bot Chat from `profiles.list(include_sessions: true)`.
+  String? get gatewayBotChatSessionId {
+    final preferred = preferredSession;
+    if (preferred == null) return null;
+    final title = preferred.rootTitle.isNotEmpty
+        ? preferred.rootTitle
+        : preferred.title;
+    if (title != 'Bot Chat') return null;
+    final id = (preferred.resolvedId ?? preferred.id).trim();
+    if (id.isEmpty ||
+        id.startsWith('mob-') ||
+        id.length > 512 ||
+        id.codeUnits.any((unit) => unit < 0x20 || unit == 0x7f)) {
+      return null;
+    }
+    return id;
+  }
+
   String? get botTitle => _botMetaText('title', 128);
 
   String? get botGroup => _botMetaText('group', 128);

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -9,7 +9,8 @@ import 'dart:math' as math;
 import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:file_picker/file_picker.dart';
-import 'package:flutter/foundation.dart' show ValueListenable, ValueNotifier;
+import 'package:flutter/foundation.dart'
+    show ValueListenable, ValueNotifier, visibleForTesting;
 import 'package:flutter/gestures.dart' show kTouchSlop;
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart'
@@ -916,6 +917,16 @@ String _stableChatReadAloudHash(String value) {
     hash = (hash * 0x01000193) & 0xffffffff;
   }
   return hash.toRadixString(16).padLeft(8, '0');
+}
+
+/// Pin persist must not block sending unless Desktop owns a conflicting slot.
+@visibleForTesting
+bool botChatPinPersistIsAuthoritativeConflict(Object error) {
+  if (error is! TuiGatewayRpcError) return false;
+  final text = error.message.toLowerCase();
+  return text.contains('changed concurrently') ||
+      text.contains('is malformed') ||
+      text.contains('invalid canonical bot chat identity');
 }
 
 class ChatScreen extends StatefulWidget {
@@ -3998,18 +4009,16 @@ class _ChatScreenState extends State<ChatScreen>
         }
         try {
           // Materialises + hides the row and then performs a fresh namespaced
-          // read-modify-write before prompt.submit. Any ambiguous server failure
-          // propagates so the encrypted draft stays retryable and no unpinned
-          // hidden conversation is started.
+          // read-modify-write. Concurrent Desktop pin changes stay fail-closed.
+          // Other persist failures (pending title, configure, older gateways)
+          // must not block prompt.submit: the turn already has a live runtime.
           await gateway.persistCanonicalBotChat(
             profile: _chat.sessionProfile,
             runtimeSessionId: runtimeId,
             storedSessionId: durableId,
           );
         } on TuiGatewayRpcError catch (error) {
-          // Legacy gateways keep the existing encrypted local fallback. Network,
-          // validation and concurrent-pin failures remain fail-closed.
-          if (error.code != -32601) rethrow;
+          if (botChatPinPersistIsAuthoritativeConflict(error)) rethrow;
           needsLocalFallback = true;
         }
       }

--- a/lib/core/screens/mission_control_screen.dart
+++ b/lib/core/screens/mission_control_screen.dart
@@ -665,8 +665,10 @@ class _MissionControlScreenState extends State<MissionControlScreen>
   /// (Desktop envía el mismo texto al crear el agente).
   Future<void> _openChat(MissionAgent agent, {String? kickoffPrompt}) async {
     final officialPin = agent.profile.botChatSessionId;
-    final officialMetadata =
-        agent.profile.botModeMetadataPublished || officialPin != null;
+    final desktopCleared = agent.profile.desktopClearedBotChatPin;
+    final gatewayPin = desktopCleared
+        ? null
+        : agent.profile.gatewayBotChatSessionId;
     if (agent.profile.hasInvalidBotChatPin) {
       debugPrint(
         'Mission Control: Bot Chat unavailable for ${agent.profile.name} '
@@ -678,13 +680,12 @@ class _MissionControlScreenState extends State<MissionControlScreen>
       return;
     }
     String? localPin;
-    if (officialMetadata) {
+    if (officialPin != null || desktopCleared) {
       if (!widget.connection.readOnly) {
         try {
-          // Once Desktop publishes the namespace it is authoritative,
-          // including an explicit absence of `chat`. Removing this fallback
-          // prevents an older Console-only conversation from resurrecting
-          // after a repin. Read-only mode must not mutate local state.
+          // Desktop owns the slot when it publishes a durable id or an
+          // explicit `chat: null` reset. Appearance-only `hermes-bots`
+          // metadata (no chat key) is not a reset — keep the local pin.
           await _botChatStore.clear(
             connectionId: widget.connection.id,
             profile: agent.profile.name,
@@ -716,7 +717,13 @@ class _MissionControlScreenState extends State<MissionControlScreen>
       localPin = lookup.sessionId;
     }
     if (!mounted) return;
-    final pinnedId = officialPin ?? localPin;
+    var pinnedId = officialPin ?? gatewayPin ?? localPin;
+    if (pinnedId == null &&
+        !desktopCleared &&
+        widget.botChatOpenObserver == null) {
+      pinnedId = await _discoverHiddenBotChat(agent.profile.name);
+      if (!mounted) return;
+    }
     final session = Session(
       id: 'mob-bot-${agent.profile.name}',
       lineageRootId: pinnedId,
@@ -759,6 +766,22 @@ class _MissionControlScreenState extends State<MissionControlScreen>
     // before the next tap so a stale authoritative-null profile cannot dispose
     // the live canonical binding and reopen an empty conversation.
     if (mounted) await _load(refresh: true);
+  }
+
+  Future<String?> _discoverHiddenBotChat(String profile) async {
+    final assets = _profileAssetsGateway;
+    final gateway =
+        _ownedProfileAssetsGateway ??
+        (assets is TuiGatewayClient ? assets : null);
+    if (gateway == null) return null;
+    try {
+      return await gateway.findCanonicalBotChat(profile: profile);
+    } catch (error) {
+      debugPrint(
+        'Mission Control: hidden Bot Chat lookup for $profile failed: $error',
+      );
+      return null;
+    }
   }
 
   void _showBotChatPinUnavailable() {

--- a/lib/core/services/tui_gateway_client.dart
+++ b/lib/core/services/tui_gateway_client.dart
@@ -1297,6 +1297,52 @@ class TuiGatewayClient
     }
   }
 
+  /// Locates the hidden forever-chat titled `Bot Chat` for [profile].
+  ///
+  /// Stock Hermes Agent often has that row without `ui_meta.hermes-bots.chat`.
+  /// `session.list` omits it unless `include_hidden` is set. Returns null when
+  /// the method is missing or no titled row exists — callers then create on
+  /// first submit.
+  Future<String?> findCanonicalBotChat({required String profile}) async {
+    final owner = profile.trim();
+    if (owner.isNotEmpty &&
+        !RegExp(r'^[a-z0-9][a-z0-9_-]{0,63}$').hasMatch(owner)) {
+      return null;
+    }
+    await connect();
+    Map<String, dynamic> result;
+    try {
+      result = await _request('session.list', {
+        'limit': 50,
+        'include_hidden': true,
+        if (owner.isNotEmpty) 'profile': owner,
+      });
+    } on TuiGatewayRpcError catch (error) {
+      if (error.code == -32601) return null;
+      rethrow;
+    }
+    final sessions = result['sessions'];
+    if (sessions is! List) return null;
+    String? bestId;
+    var bestCount = -1;
+    var bestStarted = -1.0;
+    for (final raw in sessions) {
+      if (raw is! Map) continue;
+      final map = Map<String, dynamic>.from(raw);
+      if ((map['title'] as String?)?.trim() != 'Bot Chat') continue;
+      final id = _safeBotModeId('${map['id'] ?? ''}');
+      if (id == null || id.startsWith('mob-')) continue;
+      final count = (map['message_count'] as num?)?.toInt() ?? 0;
+      final started = (map['started_at'] as num?)?.toDouble() ?? 0;
+      if (count > bestCount || (count == bestCount && started > bestStarted)) {
+        bestId = id;
+        bestCount = count;
+        bestStarted = started;
+      }
+    }
+    return bestId;
+  }
+
   /// Creates a profile through the same native Gateway contract used by
   /// Hermes Desktop Bot Mode.
   ///

--- a/test/agent_profile_test.dart
+++ b/test/agent_profile_test.dart
@@ -355,6 +355,37 @@ void main() {
       expect(profile.botModeUiMeta.containsKey('chat'), isTrue);
       expect(profile.botChatSessionId, isNull);
       expect(profile.hasInvalidBotChatPin, isFalse);
+      expect(profile.desktopClearedBotChatPin, isTrue);
+      expect(profile.gatewayBotChatSessionId, isNull);
+    });
+
+    test('appearance-only hermes-bots is not a Desktop pin reset', () {
+      final profile = AgentProfile.fromJson({
+        'name': 'infra',
+        'ui_meta': {
+          'hermes-bots': {'title': 'Infra', 'shape': 'blobatar'},
+        },
+        'preferred_session': {
+          'id': '20260824_131642_e57b4c',
+          'resolved_id': '20260824_131642_e57b4c--c1',
+          'root_title': 'Bot Chat',
+          'title': 'Bot Chat 2',
+        },
+      });
+
+      expect(profile.botModeMetadataPublished, isTrue);
+      expect(profile.desktopClearedBotChatPin, isFalse);
+      expect(profile.botChatSessionId, isNull);
+      expect(profile.gatewayBotChatSessionId, '20260824_131642_e57b4c--c1');
+    });
+
+    test('preferred_session that is not Bot Chat is not a canonical pin', () {
+      final profile = AgentProfile.fromJson({
+        'name': 'infra',
+        'preferred_session': {'id': 'scratch', 'title': 'Scratch work'},
+      });
+
+      expect(profile.gatewayBotChatSessionId, isNull);
     });
 
     test('ui_meta top-level no-null debe ser un objeto', () {

--- a/test/bot_chat_pin_persist_test.dart
+++ b/test/bot_chat_pin_persist_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hermes_android/core/screens/chat_screen.dart';
+import 'package:hermes_android/core/services/tui_gateway_client.dart';
+
+void main() {
+  test('pin persist stays fail-closed only for Desktop slot conflicts', () {
+    expect(
+      botChatPinPersistIsAuthoritativeConflict(
+        const TuiGatewayRpcError(
+          'profiles.configure',
+          'Canonical Bot Chat pin changed concurrently',
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      botChatPinPersistIsAuthoritativeConflict(
+        const TuiGatewayRpcError(
+          'profiles.configure',
+          'Canonical Bot Chat pin is malformed',
+        ),
+      ),
+      isTrue,
+    );
+    expect(
+      botChatPinPersistIsAuthoritativeConflict(
+        const TuiGatewayRpcError(
+          'session.title',
+          'Hermes did not persist the canonical Bot Chat row',
+        ),
+      ),
+      isFalse,
+    );
+    expect(
+      botChatPinPersistIsAuthoritativeConflict(
+        const TuiGatewayRpcError(
+          'profiles.configure',
+          'Hermes did not persist the canonical Bot Chat pin',
+          code: -32601,
+        ),
+      ),
+      isFalse,
+    );
+  });
+}

--- a/test/mission_control_screen_test.dart
+++ b/test/mission_control_screen_test.dart
@@ -939,16 +939,18 @@ void main() {
       opened = null;
       await tester.pumpWidget(const SizedBox.shrink());
       await tester.pump();
-      final officialAbsence = AgentProfile.fromJson({
+      final officialReset = AgentProfile.fromJson({
         'name': 'infra',
-        'ui_meta': {'hermes-bots': <String, dynamic>{}},
+        'ui_meta': {
+          'hermes-bots': {'chat': null, 'title': 'Infra'},
+        },
       });
       await tester.pumpWidget(
         _host(
           manager: manager,
           botChatStore: botStore,
           botChatOpenObserver: (session) => opened = session,
-          snapshot: _snapshot(profiles: [officialAbsence]),
+          snapshot: _snapshot(profiles: [officialReset]),
         ),
       );
       await tester.pumpAndSettle();
@@ -957,6 +959,69 @@ void main() {
       expect(opened?.lineageRootId, isNull);
       expect(opened?.source, 'mobile-bot');
       expect(await botStore.load(_connection.id, 'infra'), isNull);
+    },
+  );
+
+  testWidgets(
+    'appearance-only Bot metadata keeps a local pin and prefers gateway Bot Chat',
+    (tester) async {
+      final manager = await _manager();
+      final botStore = MissionBotChatStore(manager.prefs);
+      await botStore.save(
+        connectionId: _connection.id,
+        profile: 'infra',
+        sessionId: 'stored-local-keep',
+      );
+      Session? opened;
+      final appearanceOnly = AgentProfile.fromJson({
+        'name': 'infra',
+        'ui_meta': {
+          'hermes-bots': {'title': 'Infra'},
+        },
+        'preferred_session': {
+          'id': 'stored-gateway-bot-chat',
+          'root_title': 'Bot Chat',
+          'title': 'Bot Chat',
+        },
+      });
+
+      await tester.pumpWidget(
+        _host(
+          manager: manager,
+          botChatStore: botStore,
+          botChatOpenObserver: (session) => opened = session,
+          snapshot: _snapshot(profiles: [appearanceOnly]),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _openBotChat(tester, 'infra');
+
+      expect(opened?.lineageRootId, 'stored-gateway-bot-chat');
+      expect(opened?.source, 'bot-mode-local');
+      expect(await botStore.load(_connection.id, 'infra'), 'stored-local-keep');
+
+      opened = null;
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pump();
+      final noPreferred = AgentProfile.fromJson({
+        'name': 'infra',
+        'ui_meta': {
+          'hermes-bots': {'title': 'Infra'},
+        },
+      });
+      await tester.pumpWidget(
+        _host(
+          manager: manager,
+          botChatStore: botStore,
+          botChatOpenObserver: (session) => opened = session,
+          snapshot: _snapshot(profiles: [noPreferred]),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _openBotChat(tester, 'infra');
+
+      expect(opened?.lineageRootId, 'stored-local-keep');
+      expect(opened?.source, 'bot-mode-local');
     },
   );
 

--- a/test/tui_gateway_bot_mode_contract_test.dart
+++ b/test/tui_gateway_bot_mode_contract_test.dart
@@ -131,6 +131,69 @@ void main() {
   });
 
   test(
+    'findCanonicalBotChat uses hidden session.list for the profile',
+    () async {
+      final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+      addTearDown(server.close);
+      final requests = <Map<String, dynamic>>[];
+      server.listen((request) async {
+        final socket = await WebSocketTransformer.upgrade(request);
+        await for (final raw in socket) {
+          final frame = jsonDecode(raw as String) as Map<String, dynamic>;
+          requests.add(frame);
+          socket.add(
+            jsonEncode({
+              'jsonrpc': '2.0',
+              'id': frame['id'],
+              'result': {
+                'sessions': [
+                  {
+                    'id': 'scratch',
+                    'title': 'Scratch work',
+                    'message_count': 9,
+                    'started_at': 40,
+                  },
+                  {
+                    'id': 'older-bot-chat',
+                    'title': 'Bot Chat',
+                    'message_count': 2,
+                    'started_at': 10,
+                  },
+                  {
+                    'id': 'canonical-bot-chat',
+                    'title': 'Bot Chat',
+                    'message_count': 163,
+                    'started_at': 20,
+                  },
+                  {
+                    'id': 'mob-bot-infra',
+                    'title': 'Bot Chat',
+                    'message_count': 400,
+                    'started_at': 50,
+                  },
+                ],
+              },
+            }),
+          );
+        }
+      });
+
+      final client = _clientFor(server);
+      addTearDown(client.close);
+      final id = await client.findCanonicalBotChat(profile: 'infra');
+
+      expect(requests, hasLength(1));
+      expect(requests.single['method'], 'session.list');
+      expect(requests.single['params'], {
+        'limit': 50,
+        'include_hidden': true,
+        'profile': 'infra',
+      });
+      expect(id, 'canonical-bot-chat');
+    },
+  );
+
+  test(
     'profile creation uses the native Desktop contract in one write',
     () async {
       final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);


### PR DESCRIPTION
Fixes #11.

## Problem

Bots → Open Chat currently requires `ui_meta.hermes-bots.chat` to have been written by Hermes Desktop. A stock Hermes Agent install often already has the canonical hidden session titled **Bot Chat** (created from Desktop, CLI, or an earlier client) without that pin.

When the `hermes-bots` namespace exists for appearance only (title, shape, colour — no `chat` key), Open Chat treated that as a Desktop reset: it cleared any local pin, minted a new hidden session, then ran `persistCanonicalBotChat` **before** `prompt.submit`. If title/configure did not confirm the pin, the send failed and the throwaway row was reaped. `/new` after selecting the same bot still worked, because it skips that pin RMW.

`chat: null` remains a real Desktop reset and is unchanged.

## Approach

No new Hermes endpoints.

1. If there is no official `chat` pin and Desktop did not set `chat: null`, resume:
   - `preferred_session` when its title / `root_title` is `Bot Chat`, else
   - `session.list` with `include_hidden: true` and `profile: <bot>`, picking the titled Bot Chat with the most messages.
2. Keep pin persistence (`session.title` / `set_hidden` / `profiles.configure`) **best-effort**. Only a concurrent or malformed Desktop pin still fails closed. A live runtime can still send.

## Tests

- `flutter test` on `test/agent_profile_test.dart`, `test/bot_chat_pin_persist_test.dart`, `test/tui_gateway_bot_mode_contract_test.dart`, `test/mission_control_screen_test.dart` (75 passed)
- `flutter analyze` on the changed files (clean)
- Physical: `qa` flavor from this branch on a self-hosted Hermes Agent with appearance-only `hermes-bots` metadata. Open Chat resumed the hidden Bot Chats and `prompt.submit` succeeded.
