### PR TITLE
fix(bot-chat): preserve known pins for appearance-only metadata

### DIFF
--- a/lib/core/screens/mission_control_screen.dart
+++ b/lib/core/screens/mission_control_screen.dart
@@ -665,8 +665,7 @@ class _MissionControlScreenState extends State<MissionControlScreen>
   /// (Desktop envía el mismo texto al crear el agente).
   Future<void> _openChat(MissionAgent agent, {String? kickoffPrompt}) async {
     final officialPin = agent.profile.botChatSessionId;
-    final officialMetadata =
-        agent.profile.botModeMetadataPublished || officialPin != null;
+    final officialMetadata = agent.profile.botModeUiMeta.containsKey('chat');
     if (agent.profile.hasInvalidBotChatPin) {
       debugPrint(
         'Mission Control: Bot Chat unavailable for ${agent.profile.name} '
@@ -681,10 +680,9 @@ class _MissionControlScreenState extends State<MissionControlScreen>
     if (officialMetadata) {
       if (!widget.connection.readOnly) {
         try {
-          // Once Desktop publishes the namespace it is authoritative,
-          // including an explicit absence of `chat`. Removing this fallback
-          // prevents an older Console-only conversation from resurrecting
-          // after a repin. Read-only mode must not mutate local state.
+          // A published pin or explicit `chat: null` reset is authoritative.
+          // Appearance-only metadata does not reset a known conversation.
+          // Read-only mode must not mutate local state.
           await _botChatStore.clear(
             connectionId: widget.connection.id,
             profile: agent.profile.name,

--- a/test/mission_control_screen_test.dart
+++ b/test/mission_control_screen_test.dart
@@ -899,7 +899,40 @@ void main() {
   });
 
   testWidgets(
-    'official Bot metadata retires stale local pins, including pin absence',
+    'appearance-only Bot metadata preserves the known local conversation',
+    (tester) async {
+      final manager = await _manager();
+      final botStore = MissionBotChatStore(manager.prefs);
+      await botStore.save(
+        connectionId: _connection.id,
+        profile: 'infra',
+        sessionId: 'stored-local-keep',
+      );
+      Session? opened;
+      final appearanceOnly = AgentProfile.fromJson({
+        'name': 'infra',
+        'ui_meta': {
+          'hermes-bots': {'title': 'Infra', 'shape': 'blobatar'},
+        },
+      });
+      await tester.pumpWidget(
+        _host(
+          manager: manager,
+          botChatStore: botStore,
+          botChatOpenObserver: (session) => opened = session,
+          snapshot: _snapshot(profiles: [appearanceOnly]),
+        ),
+      );
+      await tester.pumpAndSettle();
+      await _openBotChat(tester, 'infra');
+      expect(opened?.lineageRootId, 'stored-local-keep');
+      expect(opened?.source, 'bot-mode-local');
+      expect(await botStore.load(_connection.id, 'infra'), 'stored-local-keep');
+    },
+  );
+
+  testWidgets(
+    'official Bot metadata with a pin or explicit null reset retires stale local pins',
     (tester) async {
       final manager = await _manager();
       final botStore = MissionBotChatStore(manager.prefs);
@@ -941,7 +974,9 @@ void main() {
       await tester.pump();
       final officialAbsence = AgentProfile.fromJson({
         'name': 'infra',
-        'ui_meta': {'hermes-bots': <String, dynamic>{}},
+        'ui_meta': {
+          'hermes-bots': <String, dynamic>{'chat': null},
+        },
       });
       await tester.pumpWidget(
         _host(


### PR DESCRIPTION
## Change

Retain the safe metadata distinction identified by @josephsellers in #10: an appearance-only `ui_meta['hermes-bots']` object must not erase a known local Bot Chat pin.

A valid official `chat` pin still takes precedence. An explicit `chat: null` reset still retires the local fallback. Malformed metadata, corrupt/unavailable local storage, and read-only protections remain fail-closed.

Contributor attribution is preserved with a `Co-authored-by` trailer.

## Verification

- New widget regression failed before the fix: the known lineage root became null.
- Focused screen/model/storage suite: 68 tests passed, also rerun by an independent reviewer against the frozen commit.
- `flutter analyze --no-pub`: passed.
- Full local Flutter suite on Flutter 3.44.1: completed with `success: true`, no failing/error test events.
- Independent review: no blocking findings for this narrow delta.

## Not included

This does **not** adopt the hidden-session discovery algorithm from #10. Issue #11 remains unresolved: safe discovery still needs proof of profile ownership, complete enumeration, ambiguity rejection and durable ID validation. This PR does not modify Agent core, release an APK, change transports or claim physical-device validation.