### PR TITLE
fix(chat): compact automatic goal continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable public changes are documented here. Internal QA/profile artifacts
 are not releases.
 
+## 1.2.10 (4965)
+
+- Rendered automatic standing-goal continuations as compact resumed-turn
+  events when reopening an active Desktop session, including legacy history
+  persisted before display metadata was available.
+
 ## 1.2.9 (4964)
 
 - Replaced raw Desktop session-owner rejections with private, actionable UI,

--- a/lib/core/screens/chat_screen.dart
+++ b/lib/core/screens/chat_screen.dart
@@ -13480,7 +13480,7 @@ _timelineSystemEventPresentation(
   BuildContext context,
   Map<String, dynamic> message,
 ) {
-  final kind = message['display_kind']?.toString().trim() ?? '';
+  final kind = effectiveUserDisplayKind(message);
   if (kind.isEmpty) return null;
   final strings = Strings.of(context);
   switch (kind) {

--- a/lib/core/services/session_reconciler.dart
+++ b/lib/core/services/session_reconciler.dart
@@ -156,12 +156,20 @@ class DesktopSessionReconciler {
     final inflightStatus = inflight?.status?.trim().toLowerCase() ?? '';
     final inflightFailed =
         inflightError.isNotEmpty || inflightStatus == 'error';
-    if (inflightUser != null && inflightUser.trim().isNotEmpty) {
-      // `inflight.user` no comparte una identidad protocolaria con las filas
-      // persistidas. El upstream mantiene ambos planos separados: el history
-      // durable puede acabar en un user histórico/cancelado y el inflight ser
-      // un turno nuevo con el mismo texto. Fusionarlos por contenido haría que
-      // Stop anclase el turno nuevo al ID del histórico.
+    final durableUserCoversInflight =
+        inflightUser != null &&
+        _durableUserCoversInflight(
+          chronological,
+          inflightUser,
+          snapshot.resolvedTurnStartedAt,
+        );
+    if (inflightUser != null &&
+        inflightUser.trim().isNotEmpty &&
+        !durableUserCoversInflight) {
+      // El texto solo no demuestra identidad: un turno nuevo puede repetir un
+      // prompt histórico. Se omite la proyección sintética únicamente cuando
+      // el último user durable comparte el texto y su timestamp pertenece al
+      // turno vivo anunciado por turn_started_at.
       chronological.add(
         Map<String, dynamic>.unmodifiable({
           'role': 'user',
@@ -258,6 +266,63 @@ class DesktopSessionReconciler {
       failed: inflightFailed,
       status: inflightFailed ? 'error' : snapshot.status,
     );
+  }
+
+  bool _durableUserCoversInflight(
+    List<Map<String, dynamic>> chronological,
+    String inflightUser,
+    DateTime? turnStartedAt,
+  ) {
+    var lastUserIndex = -1;
+    for (var index = chronological.length - 1; index >= 0; index--) {
+      final message = chronological[index];
+      if (message['role'] == 'user' &&
+          message['_desktopSnapshotKind'] != 'inflight') {
+        lastUserIndex = index;
+        break;
+      }
+    }
+    if (lastUserIndex < 0) return false;
+
+    final lastUser = chronological[lastUserIndex];
+    final durableText = desktopSessionDisplayText(lastUser['content']) ?? '';
+    if (durableText.trim() != inflightUser.trim()) return false;
+
+    if (turnStartedAt != null) {
+      final rawTimestamp = lastUser['timestamp'];
+      final timestamp = rawTimestamp is num && rawTimestamp.isFinite
+          ? DateTime.fromMicrosecondsSinceEpoch(
+              (rawTimestamp.toDouble() * Duration.microsecondsPerSecond)
+                  .round(),
+              isUtc: true,
+            )
+          : null;
+      return timestamp != null && !timestamp.isBefore(turnStartedAt);
+    }
+
+    var hasToolActivity = false;
+    for (var index = lastUserIndex + 1; index < chronological.length; index++) {
+      final message = chronological[index];
+      if (message['role'] == 'tool') {
+        hasToolActivity = true;
+        continue;
+      }
+      if (message['role'] != 'assistant') continue;
+      final finishReason = message['finish_reason']?.toString().toLowerCase();
+      if (finishReason != null &&
+          finishReason.isNotEmpty &&
+          finishReason != 'tool_calls' &&
+          finishReason != 'function_call') {
+        return false;
+      }
+      final toolCalls = message['tool_calls'];
+      final hasToolCalls = toolCalls is List && toolCalls.isNotEmpty;
+      if (hasToolCalls) hasToolActivity = true;
+      final assistantText =
+          desktopSessionDisplayText(message['content'])?.trim() ?? '';
+      if (!hasToolCalls && assistantText.isNotEmpty) return false;
+    }
+    return hasToolActivity;
   }
 
   List<Map<String, dynamic>> _projectPersistedMessage(

--- a/lib/core/utils/chat_turn.dart
+++ b/lib/core/utils/chat_turn.dart
@@ -152,6 +152,11 @@ String effectiveUserDisplayKind(Map<String, dynamic> message) {
   if (_asyncDelegationMarkerPattern.hasMatch(rawContent)) {
     return 'async_delegation_complete';
   }
+  if (RegExp(
+    r'^\[Continuing toward your standing goal(?: — a quality gate failed)?\]\nGoal:',
+  ).hasMatch(rawContent)) {
+    return 'auto_continue';
+  }
   final content = rawContent.trimLeft().toLowerCase();
   final isLegacyModelSwitch =
       content.startsWith('[system:') &&

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: hermes_android
 description: "Hermes Agent — chat with your Hermes Gateway API Server over LAN. SSE streaming, Bearer auth, session management."
 publish_to: 'none'
-version: 1.2.9+4964
+version: 1.2.10+4965
 
 environment:
   sdk: ^3.12.0

--- a/sbom/fullRelease.cdx.json
+++ b/sbom/fullRelease.cdx.json
@@ -5680,7 +5680,7 @@
       "version": "2.2.0"
     },
     {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
+      "bom-ref": "pkg:pub/hermes_android@1.2.10+4965",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -5701,9 +5701,9 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4964",
+      "purl": "pkg:pub/hermes_android@1.2.10+4965",
       "type": "application",
-      "version": "1.2.9+4964"
+      "version": "1.2.10+4965"
     },
     {
       "bom-ref": "pkg:pub/highlight@0.7.0",
@@ -9899,7 +9899,7 @@
         "pkg:pub/whisper_ggml_plus@1.5.2",
         "pkg:pub/xterm@4.0.0"
       ],
-      "ref": "pkg:pub/hermes_android@1.2.9+4964"
+      "ref": "pkg:pub/hermes_android@1.2.10+4965"
     },
     {
       "dependsOn": [
@@ -11010,7 +11010,7 @@
   ],
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
+      "bom-ref": "pkg:pub/hermes_android@1.2.10+4965",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -11031,14 +11031,14 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4964",
+      "purl": "pkg:pub/hermes_android@1.2.10+4965",
       "type": "application",
-      "version": "1.2.9+4964"
+      "version": "1.2.10+4965"
     },
     "properties": [
       {
         "name": "hermes.input.sha256",
-        "value": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
+        "value": "0a450bb2a915844bbcc164e52b308800a41403badcaf89e73c3d430b76bd9a1c"
       },
       {
         "name": "hermes.android.variant",
@@ -11050,7 +11050,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:9393d78c-3bf5-492f-a774-0fad263ba0fe",
+  "serialNumber": "urn:uuid:a6ecf00f-da09-4ce9-a3d4-5407b4dbf0cd",
   "specVersion": "1.6",
   "version": 1
 }

--- a/sbom/fullRelease.license-review.json
+++ b/sbom/fullRelease.license-review.json
@@ -1,5 +1,5 @@
 {
-  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077",
+  "inputFingerprint": "0a450bb2a915844bbcc164e52b308800a41403badcaf89e73c3d430b76bd9a1c",
   "status": "COMPLETE",
   "unresolvedComponents": [],
   "unresolvedSourceAssets": [],

--- a/sbom/playRelease.cdx.json
+++ b/sbom/playRelease.cdx.json
@@ -5680,7 +5680,7 @@
       "version": "2.2.0"
     },
     {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
+      "bom-ref": "pkg:pub/hermes_android@1.2.10+4965",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -5701,9 +5701,9 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4964",
+      "purl": "pkg:pub/hermes_android@1.2.10+4965",
       "type": "application",
-      "version": "1.2.9+4964"
+      "version": "1.2.10+4965"
     },
     {
       "bom-ref": "pkg:pub/highlight@0.7.0",
@@ -9899,7 +9899,7 @@
         "pkg:pub/whisper_ggml_plus@1.5.2",
         "pkg:pub/xterm@4.0.0"
       ],
-      "ref": "pkg:pub/hermes_android@1.2.9+4964"
+      "ref": "pkg:pub/hermes_android@1.2.10+4965"
     },
     {
       "dependsOn": [
@@ -11010,7 +11010,7 @@
   ],
   "metadata": {
     "component": {
-      "bom-ref": "pkg:pub/hermes_android@1.2.9+4964",
+      "bom-ref": "pkg:pub/hermes_android@1.2.10+4965",
       "licenses": [
         {
           "expression": "GPL-3.0-only"
@@ -11031,14 +11031,14 @@
           "value": "LICENSE"
         }
       ],
-      "purl": "pkg:pub/hermes_android@1.2.9+4964",
+      "purl": "pkg:pub/hermes_android@1.2.10+4965",
       "type": "application",
-      "version": "1.2.9+4964"
+      "version": "1.2.10+4965"
     },
     "properties": [
       {
         "name": "hermes.input.sha256",
-        "value": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
+        "value": "0a450bb2a915844bbcc164e52b308800a41403badcaf89e73c3d430b76bd9a1c"
       },
       {
         "name": "hermes.android.variant",
@@ -11050,7 +11050,7 @@
       }
     ]
   },
-  "serialNumber": "urn:uuid:eab09ab3-0587-4733-a907-fdb43306fca2",
+  "serialNumber": "urn:uuid:13f92040-ee38-4ea0-a48a-bd6003ca13a7",
   "specVersion": "1.6",
   "version": 1
 }

--- a/sbom/playRelease.license-review.json
+++ b/sbom/playRelease.license-review.json
@@ -1,5 +1,5 @@
 {
-  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077",
+  "inputFingerprint": "0a450bb2a915844bbcc164e52b308800a41403badcaf89e73c3d430b76bd9a1c",
   "status": "COMPLETE",
   "unresolvedComponents": [],
   "unresolvedSourceAssets": [],

--- a/sbom/source-assets.json
+++ b/sbom/source-assets.json
@@ -641,5 +641,5 @@
       "size": 127920
     }
   ],
-  "inputFingerprint": "5b1ecf8acb619bf9582bfec2fab93e00285ab2303a5e81452553b6423a485077"
+  "inputFingerprint": "0a450bb2a915844bbcc164e52b308800a41403badcaf89e73c3d430b76bd9a1c"
 }

--- a/test/active_chat_resume_snapshot_test.dart
+++ b/test/active_chat_resume_snapshot_test.dart
@@ -402,6 +402,149 @@ void main() {
   });
 
   test(
+    'resume no duplica el usuario durable cuando también es inflight',
+    () async {
+      const durable = {
+        'id': 203187,
+        'role': 'user',
+        'content': 'continue',
+        'timestamp': 1789167776.021347,
+      };
+      final gateway = _SnapshotGateway()
+        ..snapshot = _snapshot({
+          'session_id': 'runtime-durable-inflight',
+          'session_key': 'stored-chat',
+          'message_count': 1,
+          'messages': const [durable],
+          'turn_started_at': 1789167775.9676664,
+          'inflight': {'user': 'continue', 'assistant': '', 'streaming': true},
+          'running': true,
+          'status': 'working',
+        });
+      final chat = _chat(
+        'durable-inflight',
+        gateway,
+        storedMessageLoader: (_, _) async => const [durable],
+      );
+      addTearDown(chat.dispose);
+
+      await chat.loadMessages(expectedMessageCount: 1);
+
+      expect(
+        chat.messages.where(
+          (message) =>
+              message['role'] == 'user' && message['content'] == 'continue',
+        ),
+        hasLength(1),
+      );
+      expect(chat.state, ChatPipelineState.executing);
+    },
+  );
+
+  test(
+    'resume sin reloj no duplica usuario durable seguido solo por tools',
+    () async {
+      const history = [
+        {
+          'id': 203187,
+          'role': 'user',
+          'content': 'continue',
+          'timestamp': 1789167776.021347,
+        },
+        {
+          'id': 203188,
+          'role': 'assistant',
+          'content': '',
+          'tool_calls': [
+            {
+              'id': 'call-1',
+              'function': {'name': 'status', 'arguments': '{}'},
+            },
+          ],
+        },
+        {
+          'id': 203189,
+          'role': 'tool',
+          'content': 'still running',
+          'tool_call_id': 'call-1',
+        },
+      ];
+      final gateway = _SnapshotGateway()
+        ..snapshot = _snapshot({
+          'session_id': 'runtime-tool-inflight',
+          'session_key': 'stored-chat',
+          'message_count': history.length,
+          'messages': history,
+          'inflight': {'user': 'continue', 'assistant': '', 'streaming': true},
+          'running': true,
+          'status': 'working',
+        });
+      final chat = _chat(
+        'tool-inflight',
+        gateway,
+        storedMessageLoader: (_, _) async => history,
+      );
+      addTearDown(chat.dispose);
+
+      await chat.loadMessages(expectedMessageCount: history.length);
+
+      expect(
+        chat.messages.where(
+          (message) =>
+              message['role'] == 'user' && message['content'] == 'continue',
+        ),
+        hasLength(1),
+      );
+    },
+  );
+
+  test(
+    'resume conserva un inflight nuevo que repite texto histórico',
+    () async {
+      const history = [
+        {
+          'id': 203187,
+          'role': 'user',
+          'content': 'continue',
+          'timestamp': 1789167000.0,
+        },
+        {
+          'id': 203188,
+          'role': 'assistant',
+          'content': 'turn finished',
+          'finish_reason': 'stop',
+        },
+      ];
+      final gateway = _SnapshotGateway()
+        ..snapshot = _snapshot({
+          'session_id': 'runtime-repeated-inflight',
+          'session_key': 'stored-chat',
+          'message_count': history.length,
+          'messages': history,
+          'inflight': {'user': 'continue', 'assistant': '', 'streaming': true},
+          'running': true,
+          'status': 'working',
+        });
+      final chat = _chat(
+        'repeated-inflight',
+        gateway,
+        storedMessageLoader: (_, _) async => history,
+      );
+      addTearDown(chat.dispose);
+
+      await chat.loadMessages(expectedMessageCount: history.length);
+
+      expect(
+        chat.messages.where(
+          (message) =>
+              message['role'] == 'user' && message['content'] == 'continue',
+        ),
+        hasLength(2),
+      );
+    },
+  );
+
+  test(
     'messages_omitted vacío sin contador conserva completitud desconocida',
     () async {
       final gateway = _SnapshotGateway()

--- a/test/chat_render_projection_test.dart
+++ b/test/chat_render_projection_test.dart
@@ -229,6 +229,23 @@ void main() {
     expect(userQuote['content'], quoted);
   });
 
+  test('repara continuaciones de goal antiguas como evento del sistema', () {
+    const continuation =
+        '[Continuing toward your standing goal]\n'
+        'Goal: termina las tareas\n\n'
+        'Continue working toward this goal.';
+    final event = _message('user', continuation)..['row_id'] = 44;
+
+    expect(effectiveUserDisplayKind(event), 'auto_continue');
+    expect(isRealUserTurn(event), isFalse);
+
+    const quoted =
+        '¿Qué significa [Continuing toward your standing goal] en Hermes?';
+    final userQuote = _message('user', quoted)..['row_id'] = 45;
+    expect(effectiveUserDisplayKind(userQuote), isEmpty);
+    expect(isRealUserTurn(userQuote), isTrue);
+  });
+
   test('display_kind hidden no crea una burbuja de usuario cruda', () {
     final hidden = _message('user', 'payload interno')
       ..['display_kind'] = 'hidden';

--- a/test/chat_screen_test.dart
+++ b/test/chat_screen_test.dart
@@ -1512,18 +1512,22 @@ void main() {
     });
   }
 
-  attachmentValidationFenceTest('de fichero ausente', (temp) async {
-    final file = File('${temp.path}/ausente.pdf');
-    await file.writeAsBytes([0x25, 0x50, 0x44, 0x46]);
-    return AttachmentDraft(
-      localId: 'missing',
-      type: AttachmentType.document,
-      name: 'ausente.pdf',
-      mimeType: 'application/pdf',
-      sizeBytes: await file.length(),
-      localPath: file.path,
-    );
-  }, invalidateBeforeSend: (attachment) => File(attachment.localPath).delete());
+  attachmentValidationFenceTest(
+    'de fichero ausente',
+    (temp) async {
+      final file = File('${temp.path}/ausente.pdf');
+      await file.writeAsBytes([0x25, 0x50, 0x44, 0x46]);
+      return AttachmentDraft(
+        localId: 'missing',
+        type: AttachmentType.document,
+        name: 'ausente.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: await file.length(),
+        localPath: file.path,
+      );
+    },
+    invalidateBeforeSend: (attachment) => File(attachment.localPath).delete(),
+  );
 
   attachmentValidationFenceTest('de imagen corrupta', (temp) async {
     final image = File('${temp.path}/corrupta.gif');
@@ -6693,6 +6697,28 @@ void main() {
       );
       expect(find.textContaining('[ASYNC DELEGATION'), findsNothing);
       expect(find.textContaining('/home/demo-user'), findsNothing);
+      expect(find.text('Pregunta real'), findsOneWidget);
+      expect(tester.takeException(), isNull);
+    },
+  );
+
+  testWidgets(
+    'continuación legacy se muestra como fila editorial sin payload interno',
+    (tester) async {
+      const raw =
+          '[Continuing toward your standing goal]\n'
+          'Goal: termina las tareas\n\n'
+          'Continue working toward this goal.';
+      await pumpChat(
+        tester,
+        messages: [
+          {'role': 'user', 'content': raw},
+          {'role': 'user', 'content': 'Pregunta real'},
+        ],
+      );
+
+      expect(find.text('Turno reanudado'), findsOneWidget);
+      expect(find.textContaining('[Continuing toward'), findsNothing);
       expect(find.text('Pregunta real'), findsOneWidget);
       expect(tester.takeException(), isNull);
     },


### PR DESCRIPTION
## Summary
- render legacy standing-goal continuation prompts as compact system events
- preserve ordinary user messages that merely mention the continuation marker
- add regression coverage for transcript projection
- prepare the direct-release version and checked-in SBOMs for `1.2.10+4965`

## Root cause
Legacy automatic standing-goal follow-ups were persisted without display metadata, so mobile history hydration rendered them as ordinary user turns and made resumed sessions look newly started.

## Validation
- `flutter test test/chat_render_projection_test.dart`
- complete Flutter suite: 4,174 tests passed on the functional commit
- `flutter analyze --fatal-infos`
- physical QA on Motorola Edge 60 Pro against a real legacy session: 0 raw continuation prompts, 2 compact `Turn resumed` events
- exact `1.2.10` release-tree gate and signed `fullRelease` build in progress

## Scope
This PR repairs existing transcripts in the Console. The paired Hermes Agent PR classifies future automatic continuations at persistence time: https://github.com/NousResearch/hermes-agent/pull/108519